### PR TITLE
Hotfix: cannot receive scan topic with best-effort QoS.

### DIFF
--- a/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h
+++ b/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h
@@ -137,9 +137,12 @@ void rle(OutputIterator& out, const Iterator & begin, const Iterator & end){
 			count=1;
 		}
 	}
+
 	if (count>0)
+	{
 		*out=std::make_pair(current,count);
 		out++;
+	}
 }
 
 //BEGIN legacy

--- a/slam_gmapping/src/slam_gmapping.cpp
+++ b/slam_gmapping/src/slam_gmapping.cpp
@@ -96,7 +96,7 @@ void SlamGmapping::startLiveSlam() {
     sst_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("map");
     sstm_ = this->create_publisher<nav_msgs::msg::MapMetaData>("map_metadata");
     scan_filter_sub_ = std::make_shared<message_filters::Subscriber<sensor_msgs::msg::LaserScan>>
-            (node_, "scan");
+            (node_, "scan", rmw_qos_profile_sensor_data);
     scan_filter_ = std::make_shared<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>>
             (*scan_filter_sub_, *buffer_, odom_frame_, 10, node_);
     scan_filter_->registerCallback(std::bind(&SlamGmapping::laserCallback, this, std::placeholders::_1));


### PR DESCRIPTION
Original implementation uses message_filters to subscribe to the scan topic. 
But message_filters default only passes topic with reliable QoS. 
I modified the QoS setting in message_filters to pass both reliable and best-effort topics.
And I have merged some modifications from @bergercookie's fork.
